### PR TITLE
Workaround for fling down issue with AppBarLayout

### DIFF
--- a/example/src/main/java/net/cattaka/android/snippets/example/AppBarLayoutExample2Activity.java
+++ b/example/src/main/java/net/cattaka/android/snippets/example/AppBarLayoutExample2Activity.java
@@ -15,6 +15,7 @@ import android.widget.CompoundButton;
 import net.cattaka.android.adaptertoolbox.adapter.ScrambleAdapter;
 import net.cattaka.android.snippets.CoordinatorLayoutUtils;
 import net.cattaka.android.snippets.example.adapter.factory.SimpleStringViewHolderFactory;
+import net.cattaka.android.snippets.example.utils.RelayForEnterAlwaysCollapsed;
 
 import java.util.ArrayList;
 
@@ -74,6 +75,8 @@ public class AppBarLayoutExample2Activity extends AppCompatActivity implements V
                 mAdapter.getItems().add("Item : " + mAdapter.getItems().size());
             }
         }
+
+        RelayForEnterAlwaysCollapsed.apply(mRecyclerView, mCoordinatorLayout, mAppBarLayout);
     }
 
     @Override

--- a/example/src/main/java/net/cattaka/android/snippets/example/utils/RelayForEnterAlwaysCollapsed.java
+++ b/example/src/main/java/net/cattaka/android/snippets/example/utils/RelayForEnterAlwaysCollapsed.java
@@ -1,0 +1,56 @@
+package net.cattaka.android.snippets.example.utils;
+
+import android.os.SystemClock;
+import android.support.annotation.NonNull;
+import android.support.design.widget.AppBarLayout;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.v7.widget.RecyclerView;
+
+/**
+ * Created by cattaka on 17/02/19.
+ */
+
+    public class RelayForEnterAlwaysCollapsed {
+    public static RecyclerView.OnScrollListener apply(@NonNull RecyclerView target, @NonNull CoordinatorLayout coordinatorLayout, @NonNull AppBarLayout appBarLayout) {
+        ForRecyclerView listener = new ForRecyclerView(coordinatorLayout, appBarLayout);
+        target.addOnScrollListener(listener);
+        return listener;
+    }
+
+    public static class ForRecyclerView extends RecyclerView.OnScrollListener {
+        CoordinatorLayout mCoordinatorLayout;
+        AppBarLayout mAppBarLayout;
+        long mLastTime;
+        float mLastVelX;
+        float mLastVelY;
+
+        public ForRecyclerView(@NonNull CoordinatorLayout coordinatorLayout, @NonNull AppBarLayout appBarLayout) {
+            mCoordinatorLayout = coordinatorLayout;
+            mAppBarLayout = appBarLayout;
+        }
+
+        @Override
+        public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+            super.onScrollStateChanged(recyclerView, newState);
+            if (newState == RecyclerView.SCROLL_STATE_IDLE) {
+                CoordinatorLayout.LayoutParams params = (CoordinatorLayout.LayoutParams) mAppBarLayout.getLayoutParams();
+                AppBarLayout.Behavior behavior = (AppBarLayout.Behavior) params.getBehavior();
+                if (behavior != null) {
+                    behavior.onNestedFling(mCoordinatorLayout, mAppBarLayout, null, mLastVelX, mLastVelY, false);
+                }
+            }
+        }
+
+        @Override
+        public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+            super.onScrolled(recyclerView, dx, dy);
+            long t = SystemClock.elapsedRealtime();
+            if (t > mLastTime) {
+                float dt = (float) (t - mLastTime) / 1000f;
+                mLastVelX = (float) dx / dt;
+                mLastVelY = (float) dy / dt;
+            }
+            mLastTime = t;
+        }
+    }
+}


### PR DESCRIPTION
When fling down the RecyclerView with enterAlwaysCollapsed, The scrolling is stop on end of RecyclerView. It does not propagate to AppBarLayout.
So this PR relay the scroll velocity from RecyclerView to AppBarLayout on RecyclerView's scroll is finished.

## Before
![ezgif-1-cd673f6ed2](https://cloud.githubusercontent.com/assets/1239253/23114766/5be6a52c-f784-11e6-9cd6-fbeef42319ca.gif)

## After
![ezgif-1-9c39feaa5f](https://cloud.githubusercontent.com/assets/1239253/23114920/2258dd24-f785-11e6-900e-d5a44c6d98dc.gif)
